### PR TITLE
Update zbx_edgemax_template.xml

### DIFF
--- a/zabbix5.0/zbx_edgemax_template.xml
+++ b/zabbix5.0/zbx_edgemax_template.xml
@@ -13,7 +13,7 @@
             <name>Template EdgeMAX SNMPv2</name>
             <templates>
                 <template>
-                    <name>Template Net Network Generic Device SNMP</name>
+                    <name>Template Net Network Generic Device SNMPv2</name>
                 </template>
             </templates>
             <groups>


### PR DESCRIPTION
"fixed" this by changing the line 16:
was:
<name>Template Net Network Generic Device SNMP</name>
to
<name>Template Net Network Generic Device SNMPv2</name>

According to https://github.com/albinbatman/zabbix-edgemax-template/issues/6